### PR TITLE
fixed time displays for sessions - Nail

### DIFF
--- a/blueprints/jam_session/jam_sessions.py
+++ b/blueprints/jam_session/jam_sessions.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, request, abort, session, flash
 from dotenv import load_dotenv
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from models import UserTable, db, JamSession, Party
 
 load_dotenv()
@@ -17,6 +17,14 @@ def get_sessions():
     current_date = datetime.now().strftime('%Y-%m-%dT%H:%M')
     max_date = datetime(2024, 12, 31,23)
     active_jam_sessions = JamSession.query.all()
+
+    if active_jam_sessions:
+        for seshs in active_jam_sessions:
+            delta = datetime.now() - seshs.date
+            secs = delta.total_seconds()
+            if secs > 300:
+                db.session.delete(seshs)
+                db.session.commit()
 
     # Used for Google Map pins
     jam_session_data = []

--- a/models.py
+++ b/models.py
@@ -100,53 +100,54 @@ def time_since_post(pid):
     return None
 
 def time_since_jam_session(jam_session_id):
-    jam_session = JamSession.query.get(jam_session_id)
-    delta = datetime.now() - jam_session.date_posted
-    secs = delta.total_seconds()
-    if secs < 60.00:
-        return f'%.0f seconds ago' % secs
-    
-    if secs >= 60.00 and secs < (60*60):
-        secs = (secs / (60))
-        if f'%.0f'%secs == '1':
-            return f'%.0f minute ago' % secs
-        else:
-            return f'%.0f minutes ago' % secs
+    if JamSession.query.get(jam_session_id):
+        jam_session = JamSession.query.get(jam_session_id)
+        delta = datetime.now() - jam_session.date_posted
+        secs = delta.total_seconds()
+        if secs < 60.00:
+            return f'%.0f seconds ago' % secs
         
-    if secs >= (60*60) and secs <= (60*60*24):
-        secs = (secs / (60*60))
-        if f'%.0f'%secs == '1':
-            return f'%.0f hour ago' % secs
-        else:
-            return f'%.0f hours ago' % secs
-        
-    if secs >= (60*60*24) and secs <= (60*60*24*7):
-        secs = (secs / (60*60*24))
-        if f'%.0f'%secs == '1':
-            return f'%.0f day ago' % secs
-        else:
-            return f'%.0f days ago' % secs
+        if secs >= 60.00 and secs < (60*60):
+            secs = (secs / (60))
+            if f'%.0f'%secs == '1':
+                return f'%.0f minute ago' % secs
+            else:
+                return f'%.0f minutes ago' % secs
+            
+        if secs >= (60*60) and secs <= (60*60*24):
+            secs = (secs / (60*60))
+            if f'%.0f'%secs == '1':
+                return f'%.0f hour ago' % secs
+            else:
+                return f'%.0f hours ago' % secs
+            
+        if secs >= (60*60*24) and secs <= (60*60*24*7):
+            secs = (secs / (60*60*24))
+            if f'%.0f'%secs == '1':
+                return f'%.0f day ago' % secs
+            else:
+                return f'%.0f days ago' % secs
 
-    if secs >= (60*60*24*7) and secs < (60*60*24*7*4):
-        secs = (secs / (60*60*24*7))
-        if f'%.0f'%secs == '1':
-            return f'%.0f week ago' % secs
-        else:
-            return f'%.0f weeks ago' % secs
+        if secs >= (60*60*24*7) and secs < (60*60*24*7*4):
+            secs = (secs / (60*60*24*7))
+            if f'%.0f'%secs == '1':
+                return f'%.0f week ago' % secs
+            else:
+                return f'%.0f weeks ago' % secs
 
-    if secs >= (60*60*24*7*4) and secs < (60*60*24*7*4*12):
-        secs = (secs / (60*60*24*7*4))
-        if f'%.0f'%secs == '1':
-            return f'%.0f month ago' % secs
-        else:
-            return f'%.0f months ago' % secs
-        
-    if secs >= (60*60*24*7*4*12):
-        secs = (secs / (60*60*24*7*4*12))
-        if f'%.0f'%secs == '1':
-            return f'%.0f year ago' % secs
-        else:
-            return f'%.0f years ago' % secs
+        if secs >= (60*60*24*7*4) and secs < (60*60*24*7*4*12):
+            secs = (secs / (60*60*24*7*4))
+            if f'%.0f'%secs == '1':
+                return f'%.0f month ago' % secs
+            else:
+                return f'%.0f months ago' % secs
+            
+        if secs >= (60*60*24*7*4*12):
+            secs = (secs / (60*60*24*7*4*12))
+            if f'%.0f'%secs == '1':
+                return f'%.0f year ago' % secs
+            else:
+                return f'%.0f years ago' % secs
         
     return None
 


### PR DESCRIPTION
On session page, I have added a 5 minute delay before a session deletes itself from the database on its scheduled even start. This is to allow users the ability to still see information on the session incase they are arriving a little late